### PR TITLE
Fixed typo in PickupOrder constructor

### DIFF
--- a/src/Model/PickUpOrder.php
+++ b/src/Model/PickUpOrder.php
@@ -54,7 +54,7 @@ class PickUpOrder
         $this->setOrderReferenceId($orderReferenceId);
         $this->setCustomerReference($customerReference);
         $this->setCountPackages($countPackages);
-        $this->setMote($note);
+        $this->setNote($note);
         $this->setEmail($email);
         $this->setSendDate($sendDate);
         $this->setSendTimeFrom($sendTimeFrom);


### PR DESCRIPTION
There is a typo in constructor when using setMote() method. It should be setNote().