### PR TITLE
Fixed: Pallet collies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /composer.lock
 /test/config.json.old
 /test/phpunit_report
+.idea/

--- a/src/Api.php
+++ b/src/Api.php
@@ -363,7 +363,7 @@ class Api
             if ($package->getPalletInfo()) {
                 $collies = [];
                 foreach ($package->getPalletInfo()->getCollies() AS $colli) {
-                    $collies[]['MyApiPackageInColli'] = [
+                    $collies['MyApiPackageInColli'][] = [
                         'ColliNumber' => $colli->getColliNumber(),
                         'Height' => $colli->getHeight(),
                         'Length' => $colli->getLength(),

--- a/src/Api.php
+++ b/src/Api.php
@@ -363,7 +363,7 @@ class Api
             if ($package->getPalletInfo()) {
                 $collies = [];
                 foreach ($package->getPalletInfo()->getCollies() AS $colli) {
-                    $collies['MyApiPackageInColli'][] = [
+                    $collies[] = [
                         'ColliNumber' => $colli->getColliNumber(),
                         'Height' => $colli->getHeight(),
                         'Length' => $colli->getLength(),
@@ -374,7 +374,7 @@ class Api
                 }
 
                 $palletInfo = [];
-                $palletInfo['Collies'] = $collies;
+                $palletInfo['Collies']['MyApiPackageInColli'] = $collies;
                 $palletInfo['ManipulationType'] = $package->getPalletInfo()->getManipulationType();
                 $palletInfo['PEURCount'] = $package->getPalletInfo()->getPalletEurCount();
                 $palletInfo['PackDesc'] = $package->getPalletInfo()->getPackDescription();

--- a/src/Enum/CargoType.php
+++ b/src/Enum/CargoType.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (C) 2016 Adam Schubert <adam.schubert@sg1-game.net>.
+ */
+
+namespace Salamek\PplMyApi\Enum;
+
+
+class CargoType
+{
+    const DEPO = 'PT';
+    const STANDARD = 'SV';
+
+    /** @var array */
+    public static $list = [
+        self::DEPO,
+        self::STANDARD
+    ];
+}

--- a/src/Model/PalletInfo.php
+++ b/src/Model/PalletInfo.php
@@ -7,6 +7,7 @@ namespace Salamek\PplMyApi\Model;
 
 
 use Salamek\PplMyApi\Enum\ManipulationType;
+use Salamek\PplMyApi\Enum\CargoType;
 use Salamek\PplMyApi\Exception\WrongDataException;
 
 class PalletInfo
@@ -101,8 +102,8 @@ class PalletInfo
      */
     public function setPickUpCargoTypeCode($pickUpCargoTypeCode)
     {
-        if (!in_array($pickUpCargoTypeCode, ManipulationType::$list)) {
-            throw new WrongDataException(sprintf('$pickUpCargoTypeCode has wrong value, only %s are allowed', implode(', ', ManipulationType::$list)));
+        if (!in_array($pickUpCargoTypeCode, CargoType::$list)) {
+            throw new WrongDataException(sprintf('$pickUpCargoTypeCode has wrong value, only %s are allowed', implode(', ', CargoType::$list)));
         }
         $this->pickUpCargoTypeCode = $pickUpCargoTypeCode;
     }


### PR DESCRIPTION
For repeat MyApiPackageInColli, we need only one and for it create array. So Fixed restart apache / connection.

přidán ještě jeden fix, u pickUpCargoTypeCode se validuje Číselník typů svozu (pouze PPLsprint), v dokumentaci mají chybu, již jsem ji nahlásil.