### PR TITLE
Changed SpecialDelivery getters return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Check if PPL MyApi is in working shape
 $pplMyApi = new Salamek\PplMyApi\Api();
 if ($pplMyApi->isHealthy())
 {
-    echo 'Healthly :)' . PHP_EOL;
+    echo 'Healthy :)' . PHP_EOL;
 }
 else
 {
@@ -92,7 +92,7 @@ $recipient = new Salamek\PplMyApi\Model\Recipient('Olomouc', 'Adam Schubert', 'M
 
 $myPackageIdFromNumberSeries = 115;
 $weight = 3.15;
-$package = new Salamek\PplMyApi\Model\Package($myPackageIdFromNumberSeries, Product::PPL_PARCEL_CZ_PRIVATE, $weight, 'Testpvaci balik', Depo::CODE_09, $sender, $recipient);
+$package = new Salamek\PplMyApi\Model\Package($myPackageIdFromNumberSeries, Product::PPL_PARCEL_CZ_PRIVATE, $weight, 'Testovaci balik', Depo::CODE_09, $sender, $recipient);
 
 try
 {
@@ -208,7 +208,7 @@ $recipient = new Salamek\PplMyApi\Model\Recipient('Olomouc', 'Adam Schubert', 'M
 
 $myPackageIdFromNumberSeries = 115;
 $weight = 3.15;
-$package = new Salamek\PplMyApi\Model\Package($myPackageIdFromNumberSeries, Product::PPL_PARCEL_CZ_PRIVATE, $weight, 'Testpvaci balik', Depo::CODE_09, $sender, $recipient);
+$package = new Salamek\PplMyApi\Model\Package($myPackageIdFromNumberSeries, Product::PPL_PARCEL_CZ_PRIVATE, $weight, 'Testovaci balik', Depo::CODE_09, $sender, $recipient);
 
 
 $rawPdf = Label::generateLabels([$package]);

--- a/src/Api.php
+++ b/src/Api.php
@@ -407,6 +407,17 @@ class Api
                 $weightedPackageInfo['Routes'] = $routes;
             }
 
+            $specialDelivery = $package->getSpecialDelivery();
+            $specDelivery = $specialDelivery ? [
+                'ParcelShopCode' => $specialDelivery->getParcelShopCode(),
+                'SpecDelivDate' => $specialDelivery->getDeliveryDate() ? $specialDelivery->getDeliveryDate()->format('Y-m-d') : null,
+                'SpecDelivTimeFrom' => $specialDelivery->getDeliveryTimeFrom() ? $specialDelivery->getDeliveryTimeFrom()->format('H:i:s') : null,
+                'SpecDelivTimeTo' => $specialDelivery->getDeliveryTimeTo() ? $specialDelivery->getDeliveryTimeTo()->format('H:i:s') : null,
+                'SpecTakeDate' => $specialDelivery->getTakeDate() ? $specialDelivery->getTakeDate()->format('Y-m-d') : null,
+                'SpecTakeTimeFrom' => $specialDelivery->getTakeTimeFrom() ? $specialDelivery->getTakeTimeFrom()->format('H:i:s') : null,
+                'SpecTakeTimeTo' => $specialDelivery->getTakeTimeTo() ? $specialDelivery->getTakeTimeTo()->format('H:i:s') : null
+            ] : null;
+
             $packagesProcessed[] = [
                 'PackNumber' => $package->getPackageNumber(),
                 'PackProductType' => $package->getPackageProductType(),
@@ -435,15 +446,7 @@ class Api
                     'Street' => $package->getRecipient()->getStreet(),
                     'ZipCode' => $package->getRecipient()->getZipCode()
                 ],
-                'SpecDelivery' => ($package->getSpecialDelivery() ? [
-                    'ParcelShopCode' => $package->getSpecialDelivery()->getParcelShopCode(),
-                    'SpecDelivDate' => $package->getSpecialDelivery()->getDeliveryDate()->format('Y-m-d'),
-                    'SpecDelivTimeFrom' => $package->getSpecialDelivery()->getDeliveryTimeFrom()->format('H:i:s'),
-                    'SpecDelivTimeTo' => $package->getSpecialDelivery()->getDeliveryTimeTo()->format('H:i:s'),
-                    'SpecTakeDate' => $package->getSpecialDelivery()->getTakeDate()->format('Y-m-d'),
-                    'SpecTakeTimeFrom' => $package->getSpecialDelivery()->getTakeTimeFrom()->format('H:i:s'),
-                    'SpecTakeTimeTo' => $package->getSpecialDelivery()->getTakeTimeTo()->format('H:i:s')
-                ] : null),
+                'SpecDelivery' => $specDelivery,
                 'PaymentInfo' => ($package->getPaymentInfo() ? [
                     'BankAccount' => $package->getPaymentInfo()->getBankAccount(),
                     'BankCode' => $package->getPaymentInfo()->getBankCode(),

--- a/src/Api.php
+++ b/src/Api.php
@@ -103,7 +103,7 @@ class Api
      * @param null|string $username
      * @param null|string $password
      * @param null|integer $customerId
-	 * @param null|string
+     * @param null|string
      * @throws \Exception
      * @throws OfflineException
      * @throws SecurityException
@@ -254,7 +254,9 @@ class Api
             ]
         ]);
 
-	return (isset($result->GetPackagesResult->ResultData->MyApiPackageOut) ? $result->GetPackagesResult->ResultData->MyApiPackageOut : [] );
+        return isset($result->GetPackagesResult->ResultData->MyApiPackageOut)
+            ? $result->GetPackagesResult->ResultData->MyApiPackageOut
+            : [];
     }
 
     /**
@@ -392,9 +394,9 @@ class Api
 
             $weightedPackageInfo = null;
             if ($package->getWeightedPackageInfo()) {
-				$routeList = [];
+                $routeList = [];
                 foreach ($package->getWeightedPackageInfo()->getRoutes() AS $route) {
-					$routeList[]= [
+                    $routeList[]= [
                         'RouteType' => $route->getRouteType(),
                         'RouteCode' => $route->getRouteCode()
                     ];
@@ -477,12 +479,9 @@ class Api
             ]
         ]);
 
-        if (isset($result->CreatePackagesResult->ResultData->ItemResult))
-        {
-            return $result->CreatePackagesResult->ResultData->ItemResult;
-        }
-
-        return [];
+        return isset($result->CreatePackagesResult->ResultData->ItemResult)
+            ? $result->CreatePackagesResult->ResultData->ItemResult
+            : [];
     }
 
     /**

--- a/src/Enum/Product.php
+++ b/src/Enum/Product.php
@@ -53,13 +53,13 @@ class Product
     ];
 
     public static $deliverySaturday = [
-		self::PPL_PARCEL_CZ_BUSINESS,
-		self::PPL_PARCEL_CZ_BUSINESS_COD,
-		self::PPL_PARCEL_CZ_PRIVATE,
-		self::PPL_PARCEL_CZ_PRIVATE_COD,
-		self::PPL_PARCEL_CZ_AFTERNOON_PACKAGE,
-		self::PPL_PARCEL_CZ_AFTERNOON_PACKAGE_COD,
-		self::EXPORT_PACKAGE,
-		self::EXPORT_PACKAGE_COD
-	];
+        self::PPL_PARCEL_CZ_BUSINESS,
+        self::PPL_PARCEL_CZ_BUSINESS_COD,
+        self::PPL_PARCEL_CZ_PRIVATE,
+        self::PPL_PARCEL_CZ_PRIVATE_COD,
+        self::PPL_PARCEL_CZ_AFTERNOON_PACKAGE,
+        self::PPL_PARCEL_CZ_AFTERNOON_PACKAGE_COD,
+        self::EXPORT_PACKAGE,
+        self::EXPORT_PACKAGE_COD
+    ];
 }

--- a/src/Model/Colli.php
+++ b/src/Model/Colli.php
@@ -167,5 +167,4 @@ class Colli
     {
         return $this->wrapCode;
     }
-
 }

--- a/src/Model/ExternalNumber.php
+++ b/src/Model/ExternalNumber.php
@@ -64,5 +64,4 @@ class ExternalNumber
     {
         return $this->externalNumber;
     }
-
 }

--- a/src/Model/Package.php
+++ b/src/Model/Package.php
@@ -6,7 +6,6 @@
 namespace Salamek\PplMyApi\Model;
 
 
-use Salamek\PplMyApi\Enum\Flag as FlagEnum;
 use Salamek\PplMyApi\Enum\Depo;
 use Salamek\PplMyApi\Enum\Product;
 use Salamek\PplMyApi\Exception\WrongDataException;
@@ -44,7 +43,7 @@ class Package
     /** @var null|PaymentInfo */
     private $paymentInfo = null;
 
-    /** @var null|ExternalNumber */
+    /** @var null|ExternalNumber[] */
     private $externalNumbers = [];
 
     /** @var PackageService[] */
@@ -123,14 +122,13 @@ class Package
         $this->setPackageCount($packageCount);
         $this->setPackagePosition($packagePosition);
 
-
         if (!is_null($seriesNumberId)) {
             $this->setSeriesNumberId($seriesNumberId);
         }
 
-		if (in_array($flags, Product::$deliverySaturday) && is_null($palletInfo)) {
-			throw new WrongDataException('Package require flag FlagEnum::SATURDAY_DELIVERY (SD) true or false');
-		}
+        if (in_array($flags, Product::$deliverySaturday) && is_null($palletInfo)) {
+            throw new WrongDataException('Package requires Salamek\PplMyApi\Enum\Flag::SATURDAY_DELIVERY to be true or false');
+        }
     }
 
     /**

--- a/src/Model/PalletInfo.php
+++ b/src/Model/PalletInfo.php
@@ -168,5 +168,4 @@ class PalletInfo
     {
         return $this->volume;
     }
-
 }

--- a/src/Model/PaymentInfo.php
+++ b/src/Model/PaymentInfo.php
@@ -248,6 +248,4 @@ class PaymentInfo
     {
         return $this->swift;
     }
-
-
 }

--- a/src/Model/SpecialDelivery.php
+++ b/src/Model/SpecialDelivery.php
@@ -12,35 +12,35 @@ namespace Salamek\PplMyApi\Model;
 class SpecialDelivery
 {
     /** @var null|string */
-    private $parcelShopCode = null;
+    private $parcelShopCode;
 
     /** @var null|\DateTimeInterface */
-    private $deliveryDate = null;
+    private $deliveryDate;
 
     /** @var null|\DateTimeInterface */
-    private $deliveryTimeFrom = null;
+    private $deliveryTimeFrom;
 
     /** @var null|\DateTimeInterface */
-    private $deliveryTimeTo = null;
+    private $deliveryTimeTo;
 
-    /** @var \DateTimeInterface */
+    /** @var null|\DateTimeInterface */
     private $takeDate;
 
     /** @var null|\DateTimeInterface */
-    private $takeTimeFrom = null;
+    private $takeTimeFrom;
 
     /** @var null|\DateTimeInterface */
-    private $takeTimeTo = null;
+    private $takeTimeTo;
 
     /**
      * SpecialDelivery constructor.
-     * @param null|string $parcelShopCode
-     * @param \DateTimeInterface|null $deliveryDate
-     * @param \DateTimeInterface|null $deliveryTimeFrom
-     * @param \DateTimeInterface|null $deliveryTimeTo
-     * @param \DateTimeInterface $takeDate
-     * @param \DateTimeInterface|null $takeTimeFrom
-     * @param \DateTimeInterface|null $takeTimeTo
+     * @param null|string               $parcelShopCode
+     * @param \DateTimeInterface|null   $deliveryDate
+     * @param \DateTimeInterface|null   $deliveryTimeFrom
+     * @param \DateTimeInterface|null   $deliveryTimeTo
+     * @param \DateTimeInterface|null   $takeDate
+     * @param \DateTimeInterface|null   $takeTimeFrom
+     * @param \DateTimeInterface|null   $takeTimeTo
      */
     public function __construct(
         $parcelShopCode,
@@ -149,7 +149,7 @@ class SpecialDelivery
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
     public function getTakeDate()
     {


### PR DESCRIPTION
Hi, I've changed the return types of getters of SpecialDelivery class.

After we have dealt with sending a package data to PPL, we started testing our pallet data. Everything worked fine except one thing - the response from the server returned code _\#1048 (The SpecTakeDate must be specified)_ - or something like that. We were passing `null` to the ServicePackage constructor. 

But when you passed the SpecialDelivery instance to the ServicePackage constructor (with `null `value of required ParcelShopCode in the constructor - cause we don't send to any), PHP was throwing error because date's `format()` method was called on returned (in my case `null`) values in the Api class in the `createPackages()` method.

But I did not want to set those dates, only information I had to set was the SpecTakeDate and everything else could stay `null`, so I modified these getters to return already formated date/time, which is already specified in the PPL EDI documentation, and in case that values are `null`, they return `null`. 

I've also fixed some typos, whitespaces (tabs -> spaces), code style, etc ...