### PR TITLE
Update Tools.php

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -40,9 +40,11 @@ class Tools
             case Product::PPL_PARCEL_CZ_BUSINESS_COD:
                 $packageIdentifierPackageProductType = 8;
                 break;
-
+            
             case Product::EXPORT_PACKAGE:
             case Product::EXPORT_PACKAGE_COD:
+            case Product::PPL_PARCEL_CONNECT:
+            case Product::PPL_PARCEL_CONNECT_COD:
                 $packageIdentifierPackageProductType = 2;
                 break;
 


### PR DESCRIPTION
Added missing product type.

`PPL_PARCEL_CONNECT` uses the same number prefix as `EXPORT_PACKAGE`.