### PR TITLE
fixes mb_strlen(): Passing null to parameter #1 ($string) of type str…

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -97,11 +97,11 @@ class Api
      */
     public function __construct($username = null, $password = null, $customerId = null, $storage = null, $trace = true)
     {
-        if (mb_strlen($username ?? '') > 32) {
+        if ($username !== null && mb_strlen($username) > 32) {
             throw new SecurityException('$username is longer than 32 characters');
         }
 
-        if (mb_strlen($password ?? '') > 32) {
+        if ($password !== null && mb_strlen($password) > 32) {
             throw new SecurityException('$password is longer than 32 characters');
         }
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -97,11 +97,11 @@ class Api
      */
     public function __construct($username = null, $password = null, $customerId = null, $storage = null, $trace = true)
     {
-        if (mb_strlen($username) > 32) {
+        if (mb_strlen($username ?? '') > 32) {
             throw new SecurityException('$username is longer than 32 characters');
         }
 
-        if (mb_strlen($password) > 32) {
+        if (mb_strlen($password ?? '') > 32) {
             throw new SecurityException('$password is longer than 32 characters');
         }
 


### PR DESCRIPTION
při volání new Api() bez parametrů (když je nepotřebuji = když si jen chci stáhnout pobočky přes getParcelShops) dostávám chybu

```
Message: mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated

Filename: src/Api.php
```

Tento commit to fixne :)